### PR TITLE
Fix login page and redirect URL after signup

### DIFF
--- a/threpose/settings.py
+++ b/threpose/settings.py
@@ -9,7 +9,6 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
-NPM_BIN_PATH = r"C:\Program Files\nodejs\npm.cmd"
 from pathlib import Path
 import os
 import json

--- a/threpose/settings.py
+++ b/threpose/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
+NPM_BIN_PATH = r"C:\Program Files\nodejs\npm.cmd"
 from pathlib import Path
 import os
 import json

--- a/users/adapter.py
+++ b/users/adapter.py
@@ -38,18 +38,16 @@ class ProfileAccountAdapter(DefaultAccountAdapter):
             del request.session['user_email']
         request.session['user_email'] = user.email
         return user
-    
 
     def get_signup_redirect_url(self, request):
-        """Redirect to home page if user already verified and
-        redirect to redirect_url if user not verifed
+        """Redirect to home page if user already verified and redirect to redirect_url if user not verifed.
 
         Returns:
             str: url of page that want to redirect
         """
         user = EmailAddress.objects.filter(
-                user=request.user)
-        if user[0].verified == True:
+            user=request.user)
+        if user[0].verified:
             return resolve_url('/')
         return resolve_url(settings.ACCOUNT_SIGNUP_REDIRECT_URL)
 
@@ -81,7 +79,7 @@ class ProfileSocialAccountAdapter(DefaultSocialAccountAdapter):
                 user.id) + "_profile_picture.jpg")
         except (KeyError, AttributeError):
             pass
-        
+
         if 'user_email' in request.session:
             del request.session['user_email']
         request.session['user_email'] = 'SocialLogin'

--- a/users/templates/account/login.html
+++ b/users/templates/account/login.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% load account %}
-{% load account socialaccount %}
+{% load socialaccount %}
 {% load widget_tweaks %}
 {% load static tailwind_tags %}
 
@@ -25,7 +25,7 @@
 		<div class="container mx-auto">
 			<div class="flex justify-center px-6 my-12">
 				<!-- Row -->
-				<div class="w-full xl:w-3/4 lg:w-11/12 flex bg-white bg-cover rounded-lg">
+				<div class="w-full xl:w-3/4 lg:w-11/12 flex rounded-lg" style="background-color: rgba(255,255,255,0.75);">
 					<!-- Col -->
 					<div
 						class="w-full h-auto bg-gray-400 hidden lg:block lg:w-5/12 bg-cover rounded-l-lg"
@@ -91,7 +91,29 @@
                 </div>
               </div>
               <hr class="my-6 border-gray-300 w-full">
-              <button type="button"
+              <button onclick="document.location='{% provider_login_url 'google' %}'" class="w-full py-2 rounded-lg bg-white shadow-md">
+                <div class="flex justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="w-6 h-6"
+                    viewBox="0 0 48 48">
+                    <defs>
+                      <path id="a"
+                        d="M44.5 20H24v8.5h11.8C34.7 33.9 30.1 37 24 37c-7.2 0-13-5.8-13-13s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l6.4-6.4C34.6 4.1 29.6 2 24 2 11.8 2 2 11.8 2 24s9.8 22 22 22c11 0 21-8 21-22 0-1.3-.2-2.7-.5-4z" />
+                    </defs>
+                    <clipPath id="b">
+                      <use xlink:href="#a" overflow="visible" />
+                    </clipPath>
+                    <path clip-path="url(#b)" fill="#FBBC05" d="M0 37V11l17 13z" />
+                    <path clip-path="url(#b)" fill="#EA4335" d="M0 11l17 13 7-6.1L48 14V0H0z" />
+                    <path clip-path="url(#b)" fill="#34A853" d="M0 37l30-23 7.9 1L48 0v48H0z" />
+                    <path clip-path="url(#b)" fill="#4285F4" d="M48 48L17 24l-4-3 35-10z" />
+                  </svg>
+                <span class="ml-4">
+                  Login with Google
+                </span>
+                </div>
+                
+              </button>
+              {% comment %} <button type="button"
                 class="w-full block bg-white hover:bg-gray-100 focus:bg-gray-100 text-gray-900 font-semibold rounded-lg px-4 py-3 border border-gray-300">
                 <div class="flex items-center justify-center">
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="w-6 h-6"
@@ -114,7 +136,7 @@
                     </ul>
                   </span>
                 </div>
-              </button>
+              </button> {% endcomment %}
 						</form>
 					</div>
 				</div>

--- a/users/templates/account/signup.html
+++ b/users/templates/account/signup.html
@@ -25,7 +25,7 @@
 		<div class="container mx-auto">
 			<div class="flex justify-center px-6 my-12">
 				<!-- Row -->
-				<div class="w-full xl:w-3/4 lg:w-11/12 flex bg-white bg-cover rounded-lg">
+				<div class="w-full xl:w-3/4 lg:w-11/12 flex bg-cover rounded-lg" style="background-color: rgba(255,255,255,0.75);">
 					<!-- Col -->
 					<div
 						class="w-full h-auto bg-gray-400 hidden lg:block lg:w-5/12 bg-cover rounded-l-lg"


### PR DESCRIPTION
[![Build Status](https://app.travis-ci.com/ThaiRepose/thairepose.svg?branch=fix-login-page)](https://app.travis-ci.com/ThaiRepose/thairepose)
[![codecov](https://codecov.io/gh/ThaiRepose/thairepose/branch/fix-login-page/graph/badge.svg?token=uocBU8wW8W)](https://codecov.io/gh/ThaiRepose/thairepose)
### Feature
- Change login and signup opacity
- Fix google login button
- Fix OAuth signup redirect. If user signup with oauth. It not gonna redirect to verification_sent page
### Solution
- overwrite get_signup_redirect_url library function in adapter.py
- change soem html in signup and login page
### How to test?
- go to login and register page. And try to sign up
### Screen shot
![1](https://user-images.githubusercontent.com/70481664/140924421-fd9989d4-a277-432e-9826-dd3d32e90651.PNG)
![2](https://user-images.githubusercontent.com/70481664/140924478-95080cdb-d295-41d5-887b-7dc92efe698f.PNG)

